### PR TITLE
Adding AWS S3 Signed URL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ A big thank you to all contributors and supporters of this repository 💚
 <a href="https://github.com/jhalborg/" target="_blank">
   <img src="https://github.com/jhalborg.png?size=64" width="64" height="64" alt="jhalborg">
 </a>
+<a href="https://github.com/felipesabino/" target="_blank">
+  <img src="https://github.com/felipesabino.png?size=64" width="64" height="64" alt="jhalborg">
+</a>
 
 ## Help & Community [![Slack Status](https://slack.graph.cool/badge.svg)](https://slack.graph.cool)
 

--- a/file-handling/aws-s3-signed-url/README.md
+++ b/file-handling/aws-s3-signed-url/README.md
@@ -1,0 +1,80 @@
+# AWS S3 - Signed URLs
+
+Get an signed URL to allow authenticated uploads to AWS S3 from clients, without exposing your AWS KEYs
+
+More info on using AWS S3 Signed URLs for file uploading at [http://docs.aws.amazon.com/AmazonS3/latest/dev/PresignedUrlUploadObject.html](http://docs.aws.amazon.com/AmazonS3/latest/dev/PresignedUrlUploadObject.html)
+
+## Example GraphQL request
+
+```graphql
+{
+  SignedUrl(filePath: "filePath.jpg") {
+    fileName
+    signedUrl
+    getUrl
+  }
+}
+```
+
+Example return
+
+```json
+{
+  "data": {
+    "SignedUrl": {
+      "fileName": "graphcool_uploads/1504353705891-filePath.jpg",
+      "signedUrl": "https://s3.amazonaws.com/_AWS_BUCKET_/graphcool_uploads/1504353705891-filePath.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=_KEY_ID_%2F20170902%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20170902T120145Z&X-Amz-Expires=300&X-Amz-Signature=d7370f599fe9feaef643baf62f70d867cf9d5b094998a28e201067c5a53fbcac&X-Amz-SignedHeaders=host",
+      "getUrl": "https://_AWS_BUCKET_.s3.amazonaws.com/graphcool_uploads/1504353705891-filePath.jpg"
+    }
+  }
+}
+```
+
+
+## Getting Started
+
+1. Create a new `Schema Extension` function
+1. Add the content of [schema.graphql](./schema.graphql) as the function's _Schema Extension DSL_
+1. Add the content of [s3.js](./s3.js) as the function's _Inline Code_
+1. Replace constants by your AWS credentials and settings.
+
+## AWS Setup
+
+1. Create an AWS bucket at https://s3.console.aws.amazon.com/s3/home
+1. Setup IAM permissions to access the bucket
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject"
+            ],
+            "Resource": "arn:aws:s3:::replace-by-your-bucket-name-here/*"
+        }
+    ]
+}
+```
+1. If you want files to be later publicly available for download, go to the bucket settings, click on Permissions and add the following bucket policy
+```
+{
+    "Version": "2012-10-17",
+    "Id": "Policy1480459267404",
+    "Statement": [
+        {
+            "Sid": "Stmt1480459264483",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::replace-by-your-bucket-name-here/*"
+        }
+    ]
+}
+```
+
+## Contributions
+
+- [@felipesabino](https://github.com/felipesabino)
+
+![](http://i.imgur.com/5RHR6Ku.png)

--- a/file-handling/aws-s3-signed-url/s3.js
+++ b/file-handling/aws-s3-signed-url/s3.js
@@ -1,0 +1,69 @@
+const AWS_ACCESS_KEY = '_ACCESS_KEY_';
+const AWS_KEY_ID = '_KEY_ID_';
+const AWS_REGION = 'us-east-1'; // values at http://docs.aws.amazon.com/general/latest/gr/rande.html
+const AWS_BUCKET = '_AWS_BUCKET_';
+const URL_EXPIRATION_TIME = 300; // 5 minutes * 60 seconds
+const FILE_PREFIX = 'graphcool_uploads/'; // prefix to add to all files befo uploading
+const SHOULD_ADD_TIMESTAMP_PREFIX = true // if should add epoch prefix to file names
+
+const AWS = require('aws-sdk') 
+
+var options = null;
+var s3 = null;
+
+var getUrlForPath = (filePath) => {
+  return `https://${options.bucket}.s3.amazonaws.com/${filePath}`;
+}
+
+var configure = () => {
+  options = {
+    awsAccessKey: AWS_ACCESS_KEY,
+    awsKeyId: AWS_KEY_ID,
+    region: AWS_REGION,
+    bucket: AWS_BUCKET,
+    signedUrlExpiration: URL_EXPIRATION_TIME,
+    filePrefix: FILE_PREFIX,
+    shouldAddTimestampPrefix: SHOULD_ADD_TIMESTAMP_PREFIX,
+  };
+
+  awsConfig = new AWS.Config({
+    credentials: new AWS.Credentials({
+      accessKeyId: options.awsKeyId,
+      secretAccessKey: options.awsAccessKey,
+      sessionToken: null,
+    }),
+    region: options.region,
+    apiVersion: 'v4',
+    signatureVersion: 'v4',
+    maxRetries: 5,
+  });
+  s3 = new AWS.S3(awsConfig);
+};
+
+module.exports = function(event) {
+  configure();
+  var fileName = event.data.filePath;
+  var timestampPrefix = options.shouldAddTimestampPrefix ? Date.now() + '-' : '';
+  var filePath = `${options.filePrefix}${timestampPrefix}${fileName}`;
+  var params = {
+  	Bucket: options.bucket,
+    Expires: options.signedUrlExpiration || 300,
+    Key: filePath,
+  };
+
+  return new Promise((resolve, reject) => {
+    s3.getSignedUrl('putObject', params, (error, url) => {
+      if (error) {
+        throw new Error(error.message);
+      } else {
+        return resolve({
+          data: {
+            fileName: filePath,
+            signedUrl: url,
+            getUrl: getUrlForPath(filePath),
+          }
+        });
+      }
+    });
+  });
+}

--- a/file-handling/aws-s3-signed-url/schema.graphql
+++ b/file-handling/aws-s3-signed-url/schema.graphql
@@ -1,0 +1,9 @@
+type SignedUrlType {
+  fileName: String!
+  signedUrl: String!
+  getUrl: String!
+}
+
+extend type Query {
+  SignedUrl(filePath: String!): SignedUrlType!
+}


### PR DESCRIPTION
Adding AWS S3 Signed URL example

S3 Signed URLs can be used to allow clients to upload files to AWS S3 without needing or exposing AWS credentials.

More info on using AWS S3 Signed URLs for file uploading at [http://docs.aws.amazon.com/AmazonS3/latest/dev/PresignedUrlUploadObject.html](http://docs.aws.amazon.com/AmazonS3/latest/dev/PresignedUrlUploadObject.html)

## Example GraphQL query request
 
```graphql
{
  SignedUrl(filePath: "filePath.jpg") {
    fileName
    signedUrl
    getUrl
  }
}
```
 
Example return
 
```json
{
  "data": {
    "SignedUrl": {
      "fileName": "graphcool_uploads/1504353705891-filePath.jpg",
      "signedUrl": "https://s3.amazonaws.com/_AWS_BUCKET_/graphcool_uploads/1504353705891-filePath.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=_KEY_ID_%2F20170902%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20170902T120145Z&X-Amz-Expires=300&X-Amz-Signature=d7370f599fe9feaef643baf62f70d867cf9d5b094998a28e201067c5a53fbcac&X-Amz-SignedHeaders=host",
      "getUrl": "https://_AWS_BUCKET_.s3.amazonaws.com/graphcool_uploads/1504353705891-filePath.jpg"
    }
  }
}
```
 


