### PR TITLE
Update email-user-management.graphql

### DIFF
--- a/authentication/email-user-management/email-user-management.graphql
+++ b/authentication/email-user-management/email-user-management.graphql
@@ -9,6 +9,7 @@ type User {
   password: String
   
   # only needed for advanced signup workflow:
-  confirmToken: String!
-  confirmExpires: DateTime!
+  confirmToken: String
+  confirmExpires: DateTime
+  confirmed: Boolean! @defaultValue(value: false)
 }


### PR DESCRIPTION
In `https://github.com/graphcool-examples/functions/blob/master/authentication/email-user-management/functions/signup/3-confirm.js` there is a field `confirmed` that is updated with the `updateUser` mutation. So we should put this in the example `User` schema.

As well, `confirmToken` and `confirmExpires` should not be required because when the `updateUser` mutation is called, it tries to sent `confirmToken` and `confirmExpires` to `null`, which is correct, but since it is required in the schema example, it will fail