### PR TITLE
fix conflict email-user template

### DIFF
--- a/auth/facebook/src/facebookAuthentication.graphql
+++ b/auth/facebook/src/facebookAuthentication.graphql
@@ -1,7 +1,7 @@
-type AuthenticateUserPayload {
+type AuthenticateFacebookUserPayload {
   token: String!
 }
 
 extend type Mutation {
-  authenticateUser(facebookToken: String!): AuthenticateUserPayload
+  authenticateFacebookUser(facebookToken: String!): AuthenticateFacebookUserPayload
 }


### PR DESCRIPTION
The google example has similar syntax (`authenticateGoogleUser`). May also be worth removing the `loggedInUser` function as well since that also conflicts with the `email-user` template.