### PR TITLE
bug fix for firebase authentication

### DIFF
--- a/community/auth/firebase-authentication/src/firebase-auth.js
+++ b/community/auth/firebase-authentication/src/firebase-auth.js
@@ -95,7 +95,9 @@ const createGraphcoolUser = async (
       const createUserResult = await api.request(`
       mutation {
         createUser(firebaseUserId: "${firebaseUserId}") {
-          User
+          User {
+            id
+          }
         }
       }`);
       const graphcoolUserId: string = createUserResult.createUser.user.id;

--- a/community/auth/firebase-authentication/src/firebase-auth.js
+++ b/community/auth/firebase-authentication/src/firebase-auth.js
@@ -95,9 +95,7 @@ const createGraphcoolUser = async (
       const createUserResult = await api.request(`
       mutation {
         createUser(firebaseUserId: "${firebaseUserId}") {
-          User {
-            id
-          }
+          id
         }
       }`);
       const graphcoolUserId: string = createUserResult.createUser.user.id;


### PR DESCRIPTION
The function ran successfully on a previously-installed schema.  When added to a new schema, this bug popped up.
Looks like you can't just ask for a whole User, so I just ask for id to be returned.