### PR TITLE
Clarify where graphcool add-template needs to be run from

### DIFF
--- a/auth/auth0/README.md
+++ b/auth/auth0/README.md
@@ -6,6 +6,7 @@ Add Auth0 Authentication to your Graphcool project 🎁
 ## Getting Started
 
 ### 1. Add the template to your Graphcool service
+From your server directory (e.g. if you were to just have run `graphcool init server` your "server directory" would be `./server`) run:
 
 ```sh
 graphcool add-template graphcool/templates/auth/auth0


### PR DESCRIPTION
It was not obvious that the command `graphcool add-template` should be run from within the server directory. Hopefully this helps to clarify things.