### PR TITLE
Fix link to Code of Conduct on GitHub

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 [fork]: https://github.com/graphcool/templates/fork
 [pr]: https://github.com/graphcool/templates/compare
-[code-of-conduct]: CODE_OF_CONDUCT.md
+[code-of-conduct]: ../CODE_OF_CONDUCT.md
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
 


### PR DESCRIPTION
The way the link was defined was referencing the local `.github` path. This fixes the url to point to the root of the repo.