### PR TITLE
email-password: Move @types/node to deps

### DIFF
--- a/auth/email-password/package.json
+++ b/auth/email-password/package.json
@@ -1,13 +1,11 @@
 {
   "dependencies": {
     "@types/bcryptjs": "^2.4.1",
+    "@types/node": "^8.0.44",
     "@types/validator": "^6.3.0",
     "bcryptjs": "^2.4.3",
     "graphcool-lib": "^0.1.0",
     "graphql-request": "^1.4.0",
     "validator": "^9.0.0"
-  },
-  "devDependencies": {
-    "@types/node": "^8.0.44"
   }
 }


### PR DESCRIPTION
It appears `devDependencies` don't get installed with `graphcool add-template`, so `graphcool deploy` throws these warnings when using the `email-password` template:

<img width="1110" alt="screen shot 2017-11-11 at 11 09 02" src="https://user-images.githubusercontent.com/761444/32691116-18b359fe-c6d1-11e7-8430-b60502339e85.png">

This pull request resolves that by moving `@types/node` from `devDependencies` to `dependencies`.