### PR TITLE
SALT ROUNDS constant not needed

### DIFF
--- a/auth/email-password/src/authenticate.ts
+++ b/auth/email-password/src/authenticate.ts
@@ -12,8 +12,6 @@ interface EventData {
   password: string
 }
 
-const SALT_ROUNDS = 10
-
 export default async (event: FunctionEvent<EventData>) => {
   console.log(event)
 


### PR DESCRIPTION
Removes unnecessary `SALT_ROUNDS` constant as it's not used here, only in Signup.ts