### PR TITLE
fix exp of token graphcool generated

### DIFF
--- a/auth/auth0/src/auth0Authentication.js
+++ b/auth/auth0/src/auth0Authentication.js
@@ -110,7 +110,7 @@ export default async event => {
     const token = await graphcool.generateNodeToken(
       graphCoolUser.id,
       'User',
-      decodedToken.exp
+      decodedToken.exp - decodedToken.iat
     )
 
     return { data: { id: graphCoolUser.id, token } }


### PR DESCRIPTION
the generateNodeToken 3d argument is a number of second, so we should use exp minus iat